### PR TITLE
Add __stepname__ attribute to plugin __init__.

### DIFF
--- a/mapclientplugins/polygonserialiserstep/__init__.py
+++ b/mapclientplugins/polygonserialiserstep/__init__.py
@@ -20,6 +20,7 @@ This file is part of MAP Client. (http://launchpad.net/mapclient)
 
 __version__ = '1.0.0'
 __author__ = 'Ju Zhang'
+__stepname__ = 'Polygon Serialiser'
 __location__ = 'https://github.com/mapclient-plugins/polygonserialiserstep/archive/v1.0.0.zip'
 
 # import class that derives itself from the step mountpoint.


### PR DESCRIPTION
This attribute is used by the MAP-Client to keep track of all the currently installed plugins, without it a number of MAP-Client plugin manager methods do not function correctly.